### PR TITLE
Update Scala example to use Databricks Connect

### DIFF
--- a/scala/ETL/README.md
+++ b/scala/ETL/README.md
@@ -7,5 +7,7 @@ the existing Databricks sample datasets.
 ## Getting started
 
 1. Import the project into your favorite IDE that can handle Maven build projects.
-2. To run make sure to set the `HOST`, `TOKEN`, and `CLUSTER` environment variables
-   to connect using Databricks Connect "v2".
+2. To run, make sure to set the environment variables for `DATABRICKS_HOST`,
+   `DATABRICKS_TOKEN`, `DATABRICKS_CLUSTER_ID`. Alternatively, please see
+   [docs](https://docs.databricks.com/en/dev-tools/databricks-connect-ref.html#set-up-the-client)
+   for other ways to configure connection with server.

--- a/scala/ETL/pom.xml
+++ b/scala/ETL/pom.xml
@@ -43,19 +43,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-    <groupId>org.apache.spark</groupId>
-    <artifactId>spark-common-utils_2.12</artifactId>
-    <version>3.5.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_2.12</artifactId>
-      <version>3.5.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-connect-client-jvm_2.12</artifactId>
-      <version>3.5.0-SNAPSHOT</version>
+      <groupId>com.databricks</groupId>
+      <artifactId>databricks-connect</artifactId>
+      <version>[13.3.0, 14.0.0)</version>
     </dependency>
   </dependencies>
 

--- a/scala/ETL/src/main/scala/com/databricks/samples/App.scala
+++ b/scala/ETL/src/main/scala/com/databricks/samples/App.scala
@@ -1,21 +1,17 @@
 package com.databricks.samples
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.dsl.expressions.StringToAttributeConversionHelper
-import org.apache.spark.sql.execution.streaming.ProcessingTimeTrigger
-import org.apache.spark.sql.functions.window
+
+import com.databricks.connect.DatabricksSession
 
 object SparkConnectSampleApplication {
-
-  def configString: String = {
-    s"sc://${System.getenv("HOST")}:443/;user_id=na;token=${System.getenv(
-        "TOKEN")};x-databricks-cluster-id=${System.getenv("CLUSTER")}"
-  }
-
   def main(args: Array[String]) {
-    val spark = SparkSession.builder().remote(configString).getOrCreate()
+
+    val spark = DatabricksSession.builder.getOrCreate()
+
+    val catalog = "main"
+    val schema = "martingrund"
 
     println("Step 1 ....")
-    val table_name_bronze = "main.martingrund.taxi_demo_bronze"
+    val table_name_bronze = s"${catalog}.${schema}.taxi_demo_bronze"
     var df = LoadData.run(spark)
     SaveData.run(df, table_name_bronze)
 
@@ -25,12 +21,12 @@ object SparkConnectSampleApplication {
     df = TransformColums.run(df)
     df = FilterInvalid.run(df)
 
-    val table_name_silver = "main.martingrund.taxi_demo_silver"
+    val table_name_silver = s"${catalog}.${schema}.taxi_demo_silver"
     SaveData.run(df, table_name_silver)
 
     println("Step 3 ...")
-    val yellow_view = "main.martingrund.taxi_demo_view_yellow"
-    val green_view = "main.martingrund.taxi_demo_view_green"
+    val yellow_view = s"${catalog}.${schema}.taxi_demo_view_yellow"
+    val green_view = s"${catalog}.${schema}.taxi_demo_view_green"
     CreateView.run(spark, table_name_silver, yellow_view, 1)
     CreateView.run(spark, table_name_silver, green_view, 2)
 


### PR DESCRIPTION
This updates the Scala ETL example to now use the recently released Scala Databricks Connect client.